### PR TITLE
Add Next.js skeleton with Prisma and Apollo

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DATABASE_URL="file:./dev.db"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# StatY Next.js Example
+
+This is a minimal Next.js application configured with **Prisma** for the
+database layer and **Apollo GraphQL** for the API layer.
+
+## Getting Started
+
+1. Install dependencies (requires access to npm):
+
+   ```bash
+   npm install
+   ```
+
+2. Generate Prisma client and migrate the SQLite database:
+
+   ```bash
+   npx prisma generate
+   npx prisma db push
+   node prisma/seed.ts
+   ```
+
+3. Run the development server:
+
+   ```bash
+   npm run dev
+   ```
+
+   Open [http://localhost:3000](http://localhost:3000) to see the app. The
+   GraphQL API is available at `/api/graphql`.
+
+## Project Structure
+
+- `pages/index.tsx` – Home page with a simple counter.
+- `pages/api/graphql.ts` – Apollo GraphQL server running as a Next.js API
+  route.
+- `prisma/schema.prisma` – Prisma schema using SQLite.
+- `.env` – Configuration file with the `DATABASE_URL` for Prisma.
+
+This repository does not include installed `node_modules` due to environment
+limitations. Ensure you have Node.js installed locally to install dependencies
+and run the application.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "staty",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "prisma": "prisma"
+  },
+  "dependencies": {
+    "next": "14.1.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "prisma": "5.14.0",
+    "@prisma/client": "5.14.0",
+    "apollo-server-micro": "3.12.0",
+    "graphql": "16.8.1"
+  }
+}

--- a/pages/api/graphql.ts
+++ b/pages/api/graphql.ts
@@ -1,0 +1,29 @@
+import { ApolloServer, gql } from 'apollo-server-micro'
+import { NextApiRequest, NextApiResponse } from 'next'
+
+const typeDefs = gql`
+  type Query {
+    hello: String!
+  }
+`
+
+const resolvers = {
+  Query: {
+    hello: () => 'Hello from Apollo!'
+  }
+}
+
+const apolloServer = new ApolloServer({ typeDefs, resolvers })
+
+const startServer = apolloServer.start()
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  await startServer
+  await apolloServer.createHandler({ path: '/api/graphql' })(req, res)
+}
+
+export const config = {
+  api: {
+    bodyParser: false
+  }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,18 @@
+import Head from 'next/head'
+import { useState } from 'react'
+
+export default function Home() {
+  const [count, setCount] = useState(0)
+  return (
+    <>
+      <Head>
+        <title>StatY</title>
+      </Head>
+      <main>
+        <h1>Hello StatY!</h1>
+        <p>Count: {count}</p>
+        <button onClick={() => setCount(count + 1)}>Increment</button>
+      </main>
+    </>
+  )
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,19 @@
+// Prisma schema file
+// Data source uses SQLite
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+// Generate the Prisma Client
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id    Int     @id @default(autoincrement())
+  name  String
+  email String  @unique
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,24 @@
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+async function main() {
+  const alice = await prisma.user.upsert({
+    where: { email: 'alice@example.com' },
+    update: {},
+    create: {
+      name: 'Alice',
+      email: 'alice@example.com'
+    }
+  })
+  console.log({ alice })
+}
+
+main()
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- initialize Next.js app skeleton
- add Prisma schema with sqlite
- configure Apollo GraphQL route
- document how to install dependencies and run the project

## Testing
- `node -v`
- `npm -v`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6877ab9fca208327aa3f01c39abf3692